### PR TITLE
Fixed reference to value member of enum

### DIFF
--- a/ios/Classes/FlutterSplendidBlePlugin.swift
+++ b/ios/Classes/FlutterSplendidBlePlugin.swift
@@ -143,7 +143,7 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
             centralManager.stopScan()
             result(nil)
             
-        case CentralMethod.connect.value:
+        case CentralMethod.connect.rawValue:
             if let arguments = call.arguments as? [String: Any],
                let deviceAddress = arguments["address"] as? String {
                 connect(deviceAddress: deviceAddress)


### PR DESCRIPTION
The `CentralMethod.connect` reference previously used a `value` member that did not exists. This PR updates this member to `rawValue` to match the structure of the other cases.