### PR TITLE
Support advertisement scan responses

### DIFF
--- a/example/lib/screens/central/device_details/components/device_details_table.dart
+++ b/example/lib/screens/central/device_details/components/device_details_table.dart
@@ -33,7 +33,7 @@ class DeviceDetailsTable extends StatelessWidget {
           children: <Widget>[
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   AppLocalizations.of(context)!.address,
@@ -46,7 +46,7 @@ class DeviceDetailsTable extends StatelessWidget {
             ),
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   device.address,
@@ -61,7 +61,7 @@ class DeviceDetailsTable extends StatelessWidget {
           children: <Widget>[
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   AppLocalizations.of(context)!.connectionStatus,
@@ -74,7 +74,7 @@ class DeviceDetailsTable extends StatelessWidget {
             ),
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   connectionState.name.capitalize(),
@@ -89,7 +89,7 @@ class DeviceDetailsTable extends StatelessWidget {
           children: <Widget>[
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   AppLocalizations.of(context)!.rssi,
@@ -102,7 +102,7 @@ class DeviceDetailsTable extends StatelessWidget {
             ),
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   device.rssi.toString(),
@@ -117,7 +117,7 @@ class DeviceDetailsTable extends StatelessWidget {
           children: <Widget>[
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
                   AppLocalizations.of(context)!.manufacturerData,
@@ -130,10 +130,10 @@ class DeviceDetailsTable extends StatelessWidget {
             ),
             TableCell(
               child: Container(
-                height: 40.0,
+                height: 50.0,
                 alignment: Alignment.center,
                 child: Text(
-                  device.manufacturerData.toString(),
+                  device.manufacturerData?.toFormattedString() ?? '',
                   style: Theme.of(context).textTheme.bodyLarge,
                   textAlign: TextAlign.center,
                 ),

--- a/example/lib/screens/central/scan/components/scan_result_tile.dart
+++ b/example/lib/screens/central/scan/components/scan_result_tile.dart
@@ -42,7 +42,7 @@ class ScanResultTile extends StatelessWidget {
           child: Table(
             columnWidths: const <int, TableColumnWidth>{
               0: FlexColumnWidth(),
-              1: FlexColumnWidth(3),
+              1: FlexColumnWidth(2),
             },
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
             children: <TableRow>[
@@ -61,7 +61,6 @@ class ScanResultTile extends StatelessWidget {
                     child: Text(
                       device.name ?? '--',
                       style: Theme.of(context).textTheme.bodySmall,
-                      textAlign: TextAlign.center,
                     ),
                   ),
                 ],
@@ -81,7 +80,6 @@ class ScanResultTile extends StatelessWidget {
                     child: Text(
                       device.address,
                       style: Theme.of(context).textTheme.bodySmall,
-                      textAlign: TextAlign.center,
                     ),
                   ),
                 ],
@@ -99,7 +97,6 @@ class ScanResultTile extends StatelessWidget {
                   ),
                   TableCell(
                     child: FractionallySizedBox(
-                      widthFactor: 0.5,
                       child: LinearProgressIndicator(
                         value: (100 - device.rssi.abs()) / 100,
                         borderRadius: BorderRadius.circular(8.0),
@@ -109,6 +106,26 @@ class ScanResultTile extends StatelessWidget {
                   ),
                 ],
               ),
+              if (device.manufacturerData != null)
+                TableRow(
+                  children: <Widget>[
+                    TableCell(
+                      child: Text(
+                        AppLocalizations.of(context)!.manufacturerData,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                    TableCell(
+                      child: Text(
+                        device.manufacturerData!.toFormattedString(),
+                        style: Theme.of(context).textTheme.bodySmall,
+                      ),
+                    ),
+                  ],
+                ),
             ],
           ),
         ),

--- a/lib/shared/models/ble_device.dart
+++ b/lib/shared/models/ble_device.dart
@@ -1,3 +1,5 @@
+import 'manufacturer_data.dart';
+
 /// Represents a discovered BLE device.
 class BleDevice {
   /// The name of the device.
@@ -14,7 +16,7 @@ class BleDevice {
   /// The manufacturer data associated with the device.
   ///
   /// Bluetooth devices are not required to provide manufacturer data so this field is nullable.
-  final String? manufacturerData;
+  final ManufacturerData? manufacturerData;
 
   /// Creates an instance of [BleDevice].
   BleDevice({
@@ -33,7 +35,8 @@ class BleDevice {
       name: map['name'] as String?,
       address: map['address'] as String,
       rssi: map['rssi'] as int,
-      manufacturerData: map['manufacturerData'] as String?,
+      manufacturerData:
+          map['manufacturerData'] == null ? null : ManufacturerData.fromString(map['manufacturerData'] as String),
     );
   }
 }

--- a/lib/shared/models/manufacturer_data.dart
+++ b/lib/shared/models/manufacturer_data.dart
@@ -1,0 +1,92 @@
+import 'dart:typed_data';
+
+/// Represents manufacturer data from a BLE device.
+///
+/// Manufacturer data is a specific type of data that can be included in the advertisement packets
+/// sent by Bluetooth Low Energy (BLE) devices. This data is used to provide additional information
+/// about the device, which can be useful for identifying the device or understanding its capabilities.
+///
+/// The manufacturer data is divided into two main parts:
+///
+/// 1. **Manufacturer Identifier**: The first two bytes of the manufacturer data represent the
+///    identifier of the manufacturer of the device or the Bluetooth radio. This identifier is
+///    assigned by the Bluetooth Special Interest Group (SIG) and is unique to each manufacturer.
+///    It helps in identifying the manufacturer of the BLE device.
+///
+/// 2. **Manufacturer-Specific Payload**: The remaining bytes of the manufacturer data are available
+///    for the BLE device firmware to use according to the designer's purposes. This payload can
+///    contain any data that the device wants to advertise, such as sensor readings, device status,
+///    or other custom information. Interpreting this data generally requires documentation or some
+///    other reference about the firmware implementation, as it is specific to the device and its
+///    manufacturer.
+///
+/// This class encapsulates the manufacturer data and provides a structure for handling it within
+/// the application.
+class ManufacturerData {
+  /// The manufacturer identifier of the device.
+  final List<int> manufacturerId;
+
+  /// The manufacturer-specific payload of the device.
+  final List<int> payload;
+
+  /// Creates an instance of [ManufacturerData].
+  ManufacturerData({
+    required this.manufacturerId,
+    required this.payload,
+  });
+
+  /// Creates an instance of [ManufacturerData] from the provided string. In the provided string, the first two bytes
+  /// represent the manufacturer identifier, and the remaining bytes represent the manufacturer-specific payload.
+  ///
+  /// This factory constructor is used with data returned from the native side in response to Method Channel calls.
+  factory ManufacturerData.fromString(String manufacturerData) {
+    // Convert the manufacturer data string to a list of integers.
+    final Uint8List manufacturerDataInts = Uint8List.fromList(
+      List<int>.generate(
+        manufacturerData.length ~/ 2,
+        (i) => int.parse(manufacturerData.substring(i * 2, i * 2 + 2), radix: 16),
+      ),
+    );
+
+    // Extract the manufacturer identifier and the payload.
+    final Uint8List manufacturerId = Uint8List.sublistView(manufacturerDataInts, 0, 2);
+    final Uint8List payload = Uint8List.sublistView(manufacturerDataInts, 2);
+
+    return ManufacturerData(
+      manufacturerId: manufacturerId,
+      payload: payload,
+    );
+  }
+
+  /// Converts the manufacturer data to a string.
+  @override
+  String toString() {
+    final List<int> manufacturerDataInts = [...manufacturerId, ...payload];
+    return String.fromCharCodes(manufacturerDataInts);
+  }
+
+  /// Converts the manufacturer data to a string that is formatted for easy reading. The manufacturer identifier is
+  /// surrounded by angle brackets to make its separation from the rest of the data more clear. A space is included
+  /// after every fourth character to separate the manufacturer data into chunks of four characters.
+  ///
+  /// The end result of this formatting is a value that looks similar to the format used by the nRF Connect for Mobile
+  /// app.
+  String toFormattedString() {
+    // Create a string representing the manufacturer identifier, surrounded by angle brackets.
+    final StringBuffer formattedString = StringBuffer('<');
+    for (int i = 0; i < manufacturerId.length; i++) {
+      formattedString.write(manufacturerId[i].toRadixString(16).padLeft(2, '0'));
+    }
+    formattedString.write('> ');
+
+    // Create a string representing the payload, with spaces after every fourth character.
+    for (int i = 0; i < payload.length; i++) {
+      formattedString.write(payload[i].toRadixString(16).padLeft(2, '0'));
+      if ((i + 1).isEven) {
+        formattedString.write(' ');
+      }
+    }
+
+    return formattedString.toString().toUpperCase();
+  }
+}

--- a/macos/Classes/FlutterSplendidBlePlugin.swift
+++ b/macos/Classes/FlutterSplendidBlePlugin.swift
@@ -255,38 +255,93 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
         emitCurrentBluetoothStatus()
     }
     
-    /// Called when a peripheral is discovered while scanning.
-    /// Adds the discovered peripheral to the map if it isn't already there and prepares the device information to be sent to Flutter.
-    /// - Parameters:
-    ///   - central: The central manager providing this update.
-    ///   - peripheral: The `CBPeripheral` that was discovered.
-    ///   - advertisementData: A dictionary containing any advertisement and scan response data.
-    ///   - RSSI: The received signal strength indicator (RSSI) value for the peripheral.
-    public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
-        // Add the peripheral to the map
-        peripheralsMap[peripheral.identifier.uuidString] = peripheral
-        
-        // Extract the manufacturer data
-        let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
-        
-        // Create a dictionary with device details
-        var deviceMap: [String: Any?] = [
-            "name": peripheral.name,
-            "address": peripheral.identifier.uuidString,
-            "rssi": RSSI.intValue,
-        ]
-        
-        // Get manufacturer data and add it to the map
-        if let manufacturerData = manufacturerData {
-            deviceMap["manufacturerData"] = manufacturerData.hexString
-        }
-        
-        // Send device information to Flutter side
-        let jsonData = try? JSONSerialization.data(withJSONObject: deviceMap, options: [])
-        if let jsonData = jsonData, let jsonString = String(data: jsonData, encoding: .utf8) {
-            centralChannel.invokeMethod("bleDeviceScanned", arguments: jsonString)
-        }
-    }
+    // A list of UUIDs discovered by the scanning process. This is used to determine if a peripheral about which data is sent in the didDiscover method
+   // below, was discovered previously. This information is, in turn, used to infer if a device has sent additional information to the device in a
+   // scan response.
+   var discoveredDevices: [UUID] = []
+
+   /// Called when a peripheral is discovered while scanning.
+   ///
+   /// Adds the discovered peripheral to the map if it isn't already there and prepares the device information to be sent to Flutter.
+   /// - Parameters:
+   ///   - central: The central manager providing this update.
+   ///   - peripheral: The `CBPeripheral` that was discovered.
+   ///   - advertisementData: A dictionary containing any advertisement and scan response data.
+   ///   - RSSI: The received signal strength indicator (RSSI) value for the peripheral.
+   ///
+   /// This function handles the discovery of BLE peripherals during a scan. It processes the advertisement data received from the peripheral
+   /// and prepares the device information to be sent to the Dart side of a Flutter application. The function supports BLE peripherals with
+   /// scannable advertisement data by leveraging the OS's automatic scan request mechanism.
+   ///
+   /// For BLE peripherals that support scannable advertisement data, the OS will automatically make a scan request after receiving the initial
+   /// advertisement packet. As a result, the `didDiscover` function will be called twice in quick succession for these devices:
+   ///
+   /// 1. The first call is triggered by the initial advertisement packet.
+   /// 2. The second call is triggered by the scan response packet.
+   ///
+   /// When this happens, the `CBPeripheral` will include additional advertisement data in the scan response, combining it with the initial data.
+   /// The function tracks the advertisement data for each discovered peripheral and waits for the scan response before sending the complete
+   /// data to the Dart side. This ensures that all relevant advertisement data, including manufacturer data, is captured and processed.
+   ///
+   /// The function uses two dictionaries to achieve this:
+   /// - `partialAdvertisementData`: Stores partial advertisement data for each peripheral.
+   /// - `scanResponseReceived`: Tracks whether the scan response has been received for each peripheral.
+   ///
+   /// The function checks the type of advertisement packet to determine if it should expect more data in a scan response. If the scan response
+   /// has been received, the function combines the initial advertisement data with the scan response data and sends the complete information
+   /// to the Dart side.
+   public func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+       // Add the peripheral to the map
+       peripheralsMap[peripheral.identifier.uuidString] = peripheral
+
+       // Check if the BLE device has indicated it supports scannable advertisement packets. If this is the case, the OS will automatically send a
+       // scan request and this function should receive another call when the scan response is received. This function will wait until all
+       // advertisement data is collected before returning it to the Dart side.
+       let isScannable = (advertisementData[CBAdvertisementDataIsConnectable] as? Bool ?? false) && discoveredDevices.contains(peripheral.identifier) == false
+
+       // Add the device to the list of discovered devices if it has not already been added
+       if discoveredDevices.contains(peripheral.identifier) == false {
+           discoveredDevices.append(peripheral.identifier)
+       }
+
+       // If the device does not indicate that more advertisement data is forthcoming, return the scan discovery information to the Dart side
+       if(!isScannable) {
+           // Create a dictionary with device details
+           var deviceMap: [String: Any?] = [
+               "name": peripheral.name,
+               "address": peripheral.identifier.uuidString,
+               "rssi": RSSI.intValue,
+           ]
+
+           // Extract the manufacturer data
+           let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+
+           // Process the manufacturer data if it exists
+           if let manufacturerData = manufacturerData {
+               // Check that the data is at least 2 bytes long (to extract the manufacturer identifier)
+               if manufacturerData.count >= 2 {
+                   // Extract the manufacturer identifier (first two bytes)
+                   let manufacturerIdData = manufacturerData.subdata(in: 0..<2)
+                   // Extract the manufacturer-specific payload (the remaining bytes)
+                   let manufacturerPayloadData = manufacturerData.subdata(in: 2..<manufacturerData.count)
+
+                   // Convert both the data parts into uppercase hexadecimal strings
+                   let manufacturerIdHex = manufacturerIdData.map { String(format: "%02X", $0) }.joined()
+                   let manufacturerPayloadHex = manufacturerPayloadData.map { String(format: "%02X", $0) }.joined()
+
+                   let formattedManufacturerData = "\(manufacturerIdHex)\(manufacturerPayloadHex)"
+
+                   deviceMap["manufacturerData"] = formattedManufacturerData
+               }
+           }
+
+           // Send device information to Flutter side
+           let jsonData = try? JSONSerialization.data(withJSONObject: deviceMap, options: [])
+           if let jsonData = jsonData, let jsonString = String(data: jsonData, encoding: .utf8) {
+               channel.invokeMethod("bleDeviceScanned", arguments: jsonString)
+           }
+       }
+   }
     
     /// Called by the system when a connection to the peripheral is successfully established.
     /// This method triggers a callback to the Flutter side to inform it of the connection status.


### PR DESCRIPTION
This PR adds support for getting complete manufacturer data from devices using scannable advertisement data. For these devices, with the current implementation, only the initial manufacturer data would be delivered in the scan results. This PR updates handling of scan results so that, if a BLE peripheral indicates that it supports scannable advertisement data, the OS will send a scan request and the resulting information from the scan response will be added to the information returned to the Dart side about the BLE device. In other words, it allows Flutter apps to get complete manufacturer data for these devices.