### PR TITLE
Updated method channel reference 🐛

### DIFF
--- a/macos/Classes/FlutterSplendidBlePlugin.swift
+++ b/macos/Classes/FlutterSplendidBlePlugin.swift
@@ -338,7 +338,7 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
            // Send device information to Flutter side
            let jsonData = try? JSONSerialization.data(withJSONObject: deviceMap, options: [])
            if let jsonData = jsonData, let jsonString = String(data: jsonData, encoding: .utf8) {
-               channel.invokeMethod("bleDeviceScanned", arguments: jsonString)
+               centralChannel.invokeMethod("bleDeviceScanned", arguments: jsonString)
            }
        }
    }


### PR DESCRIPTION
This PR fixes a bug on macOS in which the incorrect variable name was used for the Method Channel.