### PR TITLE
Fix: Implement Android Bluetooth Permission Handling (Issue #7)

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,20 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="com.splendidendeavors.flutter_splendid_ble">
 
-    <uses-permission android:name="android.permission.BLUETOOTH"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    
+    <!-- Location permissions required for BLE scanning on Android 10 and below -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    
+    <!-- Bluetooth permissions for Android 12+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 </manifest>

--- a/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/permissions/BluetoothPermissionsHandler.kt
+++ b/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/permissions/BluetoothPermissionsHandler.kt
@@ -1,0 +1,167 @@
+package com.splendidendeavors.flutter_splendid_ble.permissions
+
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry
+
+/**
+ * Handles Bluetooth permission requests and status reporting for different Android versions.
+ *
+ * This class manages the complexity of Bluetooth permissions across Android versions:
+ * - Android 12+ (API 31+): Requires BLUETOOTH_SCAN and BLUETOOTH_CONNECT permissions
+ * - Android 10-11 (API 29-30): Requires ACCESS_FINE_LOCATION permission
+ * - Android 6-9 (API 23-28): Requires ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION
+ */
+class BluetoothPermissionsHandler(
+    private val channel: MethodChannel,
+    private val context: Context
+) : PluginRegistry.RequestPermissionsResultListener {
+
+    companion object {
+        private const val PERMISSION_REQUEST_CODE = 1001
+        
+        // Permission status strings that match the Dart enum
+        private const val STATUS_GRANTED = "granted"
+        private const val STATUS_DENIED = "denied"
+    }
+
+    private var activity: Activity? = null
+    private var pendingResult: MethodChannel.Result? = null
+
+    /**
+     * Sets the activity reference needed for requesting permissions.
+     */
+    fun setActivity(activity: Activity?) {
+        this.activity = activity
+    }
+
+    /**
+     * Requests Bluetooth permissions appropriate for the current Android version.
+     *
+     * @param result The MethodChannel.Result to return the permission status
+     */
+    fun requestBluetoothPermissions(result: MethodChannel.Result) {
+        val requiredPermissions = getRequiredPermissions()
+        
+        // Check if all required permissions are already granted
+        if (arePermissionsGranted(requiredPermissions)) {
+            result.success(STATUS_GRANTED)
+            return
+        }
+
+        // Check if we have an activity to request permissions
+        if (activity == null) {
+            result.error(
+                "NO_ACTIVITY",
+                "Cannot request permissions without an activity context",
+                null
+            )
+            return
+        }
+
+        // Store the result to respond after permission request completes
+        pendingResult = result
+
+        // Request the permissions
+        ActivityCompat.requestPermissions(
+            activity!!,
+            requiredPermissions,
+            PERMISSION_REQUEST_CODE
+        )
+    }
+
+    /**
+     * Emits the current Bluetooth permission status to the Dart side.
+     * 
+     * This method immediately checks the current permission status and emits it
+     * via the method channel. Listeners on the Dart side should be set up before
+     * calling this method to ensure they receive the initial status emission.
+     */
+    fun emitCurrentPermissionStatus() {
+        val status = getCurrentPermissionStatus()
+        channel.invokeMethod("permissionStatusUpdated", status)
+    }
+
+    /**
+     * Gets the current permission status without requesting permissions.
+     *
+     * @return The current permission status as a string ("granted" or "denied")
+     */
+    private fun getCurrentPermissionStatus(): String {
+        val requiredPermissions = getRequiredPermissions()
+        return if (arePermissionsGranted(requiredPermissions)) {
+            STATUS_GRANTED
+        } else {
+            STATUS_DENIED
+        }
+    }
+
+    /**
+     * Returns the list of permissions required for the current Android version.
+     */
+    private fun getRequiredPermissions(): Array<String> {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Android 12+ (API 31+)
+            arrayOf(
+                Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_CONNECT
+            )
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Android 10-11 (API 29-30)
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        } else {
+            // Android 6-9 (API 23-28)
+            // ACCESS_COARSE_LOCATION is sufficient for BLE scanning on older versions
+            arrayOf(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    /**
+     * Checks if all specified permissions are granted.
+     *
+     * @param permissions Array of permission strings to check
+     * @return true if all permissions are granted, false otherwise
+     */
+    private fun arePermissionsGranted(permissions: Array<String>): Boolean {
+        return permissions.all { permission ->
+            ContextCompat.checkSelfPermission(context, permission) == 
+                PackageManager.PERMISSION_GRANTED
+        }
+    }
+
+    /**
+     * Handles the result of a permission request.
+     *
+     * This method is called by the Flutter plugin when permission results are received.
+     */
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ): Boolean {
+        if (requestCode != PERMISSION_REQUEST_CODE) {
+            return false
+        }
+
+        val result = pendingResult ?: return false
+        pendingResult = null
+
+        // Check if all permissions were granted
+        val allGranted = grantResults.isNotEmpty() && 
+            grantResults.all { it == PackageManager.PERMISSION_GRANTED }
+
+        val status = if (allGranted) STATUS_GRANTED else STATUS_DENIED
+        result.success(status)
+
+        // Emit the updated permission status
+        emitCurrentPermissionStatus()
+
+        return true
+    }
+}

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 android {
     namespace = "com.splendidendeavors.flutter_splendid_ble_example"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = "27.0.12077973"
+    ndkVersion = "28.2.13676358"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
@@ -24,7 +24,7 @@ android {
         applicationId = "com.splendidendeavors.flutter_splendid_ble_example"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = 23
+        minSdk = flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,21 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Bluetooth permissions for Android 11 and below -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    
+    <!-- Location permissions required for BLE scanning on Android 10 and below -->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
+    
+    <!-- Bluetooth permissions for Android 12+ -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+
     <application
         android:label="flutter_splendid_ble_example"
         android:name="${applicationName}"

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>12.0</string>
+  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '12.0'
+# platform :ios, '13.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -19,10 +19,10 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
-  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_splendid_ble: cc42af57896fbf378eca9cedff58dfbfb70f9395
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  flutter_splendid_ble: 1b3decd7bd7e090e8f321086e6ef6d97212208a9
   permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
-PODFILE CHECKSUM: 819463e6a0290f5a72f145ba7cde16e8b6ef0796
+PODFILE CHECKSUM: 4f1c12611da7338d21589c0b2ecd6bd20b109694
 
 COCOAPODS: 1.16.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,26 +2,20 @@ PODS:
   - Flutter (1.0.0)
   - flutter_splendid_ble (0.0.1):
     - Flutter
-  - permission_handler_apple (9.3.0):
-    - Flutter
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - flutter_splendid_ble (from `.symlinks/plugins/flutter_splendid_ble/ios`)
-  - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
 
 EXTERNAL SOURCES:
   Flutter:
     :path: Flutter
   flutter_splendid_ble:
     :path: ".symlinks/plugins/flutter_splendid_ble/ios"
-  permission_handler_apple:
-    :path: ".symlinks/plugins/permission_handler_apple/ios"
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
   flutter_splendid_ble: 1b3decd7bd7e090e8f321086e6ef6d97212208a9
-  permission_handler_apple: 9878588469a2b0d0fc1e048d9f43605f92e6cec2
 
 PODFILE CHECKSUM: 4f1c12611da7338d21589c0b2ecd6bd20b109694
 

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BFF9221D0DA8AE94B6E69D1 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		A037F261E32EDDA471F16085 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -109,6 +110,7 @@
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
+				78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */,
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
@@ -478,7 +480,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
@@ -607,7 +609,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -656,7 +658,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -12,11 +12,11 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		5CE05348FA8AE983ABBCDD26 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 94DF89F5CD6CD71DDA5BFE72 /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		B2ECED94491AA299FFC5ADA4 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 695CE06AC22657C7AEA3FF01 /* Pods_RunnerTests.framework */; };
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,6 +54,7 @@
 		695CE06AC22657C7AEA3FF01 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		84D2726C57ECE843F6BCE266 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		94DF89F5CD6CD71DDA5BFE72 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -66,7 +67,6 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9BFF9221D0DA8AE94B6E69D1 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		A037F261E32EDDA471F16085 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -191,9 +191,6 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -205,13 +202,15 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				4BDA60E558924C7B7804F697 /* [CP] Embed Pods Frameworks */,
-				B2C61F8965B27B060D5EEF68 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -220,9 +219,6 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -248,6 +244,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -371,23 +370,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		B2C61F8965B27B060D5EEF68 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -750,12 +732,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/example/lib/screens/central/characteristic_interaction/characteristic_interaction_controller.dart
+++ b/example/lib/screens/central/characteristic_interaction/characteristic_interaction_controller.dart
@@ -22,10 +22,15 @@ class CharacteristicInteractionController extends State<CharacteristicInteractio
   StreamSubscription<BleCharacteristicValue>? _characteristicValueListener;
 
   @override
-  Future<void> initState() async {
+  void initState() {
     super.initState();
 
     // Set a lister for changes in the characteristic value
+    _subscriptToCharacteristic();
+  }
+
+  /// Establishes a listener for changes in the value of the BLE characteristic provided to this route.
+  Future<void> _subscriptToCharacteristic() async {
     final Stream<BleCharacteristicValue> characteristicValueListener = await widget.characteristic.subscribe();
 
     _characteristicValueListener = characteristicValueListener.listen(

--- a/example/lib/screens/central/characteristic_interaction/characteristic_interaction_view.dart
+++ b/example/lib/screens/central/characteristic_interaction/characteristic_interaction_view.dart
@@ -19,136 +19,128 @@ class CharacteristicInteractionView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: const MainAppBar(),
-      body: ConstrainedBox(
-        constraints: BoxConstraints(
-          minWidth: MediaQuery.of(context).size.width,
-          maxWidth: MediaQuery.of(context).size.width,
-          minHeight: MediaQuery.of(context).size.height,
-          maxHeight: MediaQuery.of(context).size.height,
-        ),
-        child: Column(
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(top: 16.0),
-              child: Text(
-                AppLocalizations.of(context)!.characteristicInteraction,
-                style: Theme.of(context).textTheme.headlineSmall,
-                textAlign: TextAlign.center,
-              ),
-            ),
-            Padding(
-              padding: const EdgeInsets.only(bottom: 32.0),
-              child: Text(
-                state.widget.characteristic.uuid,
-                style: Theme.of(context).textTheme.bodyLarge,
-                textAlign: TextAlign.center,
-              ),
-            ),
-            ListView.builder(
-              itemCount: state.messages.length,
-              shrinkWrap: true,
-              itemBuilder: (BuildContext context, int index) {
-                // TODO(Toglefritz): update widget
-                return Card(
-                  margin: EdgeInsets.only(
-                    left: state.messages[index].source == MessageSource.mobile
-                        ? 48.0
-                        : 16.0,
-                    right:
-                        state.messages[index].source == MessageSource.peripheral
-                            ? 48.0
-                            : 16.0,
-                    top: 8.0,
-                    bottom: 8.0,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(6.0),
-                    side: BorderSide(
-                      color: Theme.of(context).primaryColor,
-                      width: 0.5,
-                    ),
-                  ),
-                  child: Padding(
-                    padding: const EdgeInsets.all(8.0),
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                      children: [
-                        Text(
-                          state.messages[index].contents,
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                        Icon(
-                          state.messages[index].source == MessageSource.mobile
-                              ? Icons.upload
-                              : Icons.download,
-                          color: Theme.of(context).disabledColor,
-                        ),
-                      ],
-                    ),
-                  ),
-                );
-              },
-            ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(bottom: 16.0),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        // TextField with rounded top left and bottom left corners.
-                        Container(
-                          width: 600,
-                          decoration: BoxDecoration(
-                            border: Border.all(
-                              color: Theme.of(context).primaryColor,
-                            ),
-                            borderRadius: const BorderRadius.all(
-                              Radius.circular(12.0),
-                            ),
-                          ),
-                          child: TextField(
-                            controller: state.controller,
-                            minLines: 1,
-                            maxLines: null,
-                            decoration: InputDecoration(
-                              contentPadding: const EdgeInsets.symmetric(
-                                vertical: 10.0,
-                                horizontal: 10.0,
-                              ),
-                              border: const OutlineInputBorder(
-                                borderSide: BorderSide.none,
-                              ),
-                              focusedBorder: const OutlineInputBorder(
-                                borderSide: BorderSide.none,
-                              ),
-                              suffixIcon: GestureDetector(
-                                onTap: state.onEntrySubmitted,
-                                child: Icon(
-                                  Icons.send,
-                                  color: Theme.of(context).primaryColor,
-                                ),
-                              ),
-                            ),
-                            style: Theme.of(context)
-                                .textTheme
-                                .labelLarge
-                                ?.copyWith(
-                                  color: Theme.of(context).primaryColor,
-                                ),
-                            cursorColor: Theme.of(context).primaryColor,
-                            onSubmitted: (value) => state.onEntrySubmitted,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ],
+      body: SafeArea(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(
+            minWidth: MediaQuery.of(context).size.width,
+            maxWidth: MediaQuery.of(context).size.width,
+            minHeight: MediaQuery.of(context).size.height,
+            maxHeight: MediaQuery.of(context).size.height,
+          ),
+          child: Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(top: 16.0),
+                child: Text(
+                  AppLocalizations.of(context)!.characteristicInteraction,
+                  style: Theme.of(context).textTheme.headlineSmall,
+                  textAlign: TextAlign.center,
                 ),
               ),
-            ),
-          ],
+              Padding(
+                padding: const EdgeInsets.only(bottom: 32.0),
+                child: Text(
+                  state.widget.characteristic.uuid,
+                  style: Theme.of(context).textTheme.bodyLarge,
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              ListView.builder(
+                itemCount: state.messages.length,
+                shrinkWrap: true,
+                itemBuilder: (BuildContext context, int index) {
+                  // TODO(Toglefritz): update widget
+                  return Card(
+                    margin: EdgeInsets.only(
+                      left: state.messages[index].source == MessageSource.mobile ? 48.0 : 16.0,
+                      right: state.messages[index].source == MessageSource.peripheral ? 48.0 : 16.0,
+                      top: 8.0,
+                      bottom: 8.0,
+                    ),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(6.0),
+                      side: BorderSide(
+                        color: Theme.of(context).primaryColor,
+                        width: 0.5,
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(8.0),
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          Text(
+                            state.messages[index].contents,
+                            style: Theme.of(context).textTheme.bodyMedium,
+                          ),
+                          Icon(
+                            state.messages[index].source == MessageSource.mobile ? Icons.upload : Icons.download,
+                            color: Theme.of(context).disabledColor,
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.only(bottom: 16.0),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: <Widget>[
+                          // TextField with rounded top left and bottom left corners.
+                          Container(
+                            width: MediaQuery.of(context).size.width * 0.9,
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                color: Theme.of(context).primaryColor,
+                              ),
+                              borderRadius: const BorderRadius.all(
+                                Radius.circular(12.0),
+                              ),
+                            ),
+                            child: TextField(
+                              controller: state.controller,
+                              minLines: 1,
+                              maxLines: null,
+                              decoration: InputDecoration(
+                                contentPadding: const EdgeInsets.symmetric(
+                                  vertical: 10.0,
+                                  horizontal: 10.0,
+                                ),
+                                border: const OutlineInputBorder(
+                                  borderSide: BorderSide.none,
+                                ),
+                                focusedBorder: const OutlineInputBorder(
+                                  borderSide: BorderSide.none,
+                                ),
+                                suffixIcon: GestureDetector(
+                                  onTap: state.onEntrySubmitted,
+                                  child: Icon(
+                                    Icons.send,
+                                    color: Theme.of(context).primaryColor,
+                                  ),
+                                ),
+                              ),
+                              style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                                    color: Theme.of(context).primaryColor,
+                                  ),
+                              cursorColor: Theme.of(context).primaryColor,
+                              onSubmitted: (value) => state.onEntrySubmitted,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,11 +84,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_web_plugins:
-    dependency: transitive
-    description: flutter
-    source: sdk
-    version: "0.0.0"
   fuchsia_remote_debug_protocol:
     dependency: transitive
     description: flutter
@@ -151,10 +146,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
@@ -163,54 +158,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
-  permission_handler:
-    dependency: "direct main"
-    description:
-      name: permission_handler
-      sha256: bc917da36261b00137bbc8896bf1482169cd76f866282368948f032c8c1caae1
-      url: "https://pub.dev"
-    source: hosted
-    version: "12.0.1"
-  permission_handler_android:
-    dependency: transitive
-    description:
-      name: permission_handler_android
-      sha256: "1e3bc410ca1bf84662104b100eb126e066cb55791b7451307f9708d4007350e6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "13.0.1"
-  permission_handler_apple:
-    dependency: transitive
-    description:
-      name: permission_handler_apple
-      sha256: f000131e755c54cf4d84a5d8bd6e4149e262cc31c5a8b1d698de1ac85fa41023
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.4.7"
-  permission_handler_html:
-    dependency: transitive
-    description:
-      name: permission_handler_html
-      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.1"
-  permission_handler_platform_interface:
-    dependency: transitive
-    description:
-      name: permission_handler_platform_interface
-      sha256: eb99b295153abce5d683cac8c02e22faab63e50679b937fa1bf67d58bb282878
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.0"
-  permission_handler_windows:
-    dependency: transitive
-    description:
-      name: permission_handler_windows
-      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.1"
   platform:
     dependency: transitive
     description:
@@ -292,10 +239,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   vector_math:
     dependency: transitive
     description:
@@ -330,4 +277,4 @@ packages:
     version: "3.1.0"
 sdks:
   dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.18.0-18.0.pre.54"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -21,8 +21,6 @@ dependencies:
     path: ../
   # Provides internationalization and localization
   intl: ^0.20.2
-  # Provides a cross-platform (iOS, Android) API to request and check permissions
-  permission_handler: ^12.0.1
 
 dev_dependencies:
   flutter_test:

--- a/lib/shared/ble_common_utilities.dart
+++ b/lib/shared/ble_common_utilities.dart
@@ -26,9 +26,11 @@ class BleCommonUtilities {
   static Future<BluetoothStatus> checkBluetoothAdapterStatus(
     MethodChannel channel,
   ) async {
-    final String statusString = await channel.invokeMethod('checkBluetoothAdapterStatus') as String;
+    final String statusString =
+        await channel.invokeMethod('checkBluetoothAdapterStatus') as String;
 
-    return BluetoothStatus.values.firstWhere((e) => e.identifier == statusString);
+    return BluetoothStatus.values
+        .firstWhere((e) => e.identifier == statusString);
   }
 
   /// Emits the current Bluetooth adapter status to the Dart side.
@@ -47,7 +49,8 @@ class BleCommonUtilities {
   static Future<Stream<BluetoothStatus>> emitCurrentBluetoothStatus(
     MethodChannel channel,
   ) async {
-    final StreamController<BluetoothStatus> streamController = StreamController<BluetoothStatus>.broadcast();
+    final StreamController<BluetoothStatus> streamController =
+        StreamController<BluetoothStatus>.broadcast();
 
     // Listen to the platform side for Bluetooth adapter status updates.
     channel.setMethodCallHandler((MethodCall call) async {
@@ -64,8 +67,11 @@ class BleCommonUtilities {
       }
     });
 
-    // Begin emitting Bluetooth adapter status updates from the platform side.
-    await channel.invokeMethod('emitCurrentBluetoothStatus');
+    // Use a microtask to ensure the stream is returned before the native method is invoked
+    // This gives the caller a chance to set up their listener before the first value is emitted
+    unawaited(Future.microtask(() async {
+      await channel.invokeMethod('emitCurrentBluetoothStatus');
+    }));
 
     return streamController.stream;
   }
@@ -82,8 +88,10 @@ class BleCommonUtilities {
   static Future<BluetoothPermissionStatus> requestBluetoothPermissions(
     MethodChannel channel,
   ) async {
-    final String permissionStatusString = await channel.invokeMethod('requestBluetoothPermissions') as String;
-    return BluetoothPermissionStatus.values.firstWhere((status) => status.identifier == permissionStatusString);
+    final String permissionStatusString =
+        await channel.invokeMethod('requestBluetoothPermissions') as String;
+    return BluetoothPermissionStatus.values
+        .firstWhere((status) => status.identifier == permissionStatusString);
   }
 
   /// Emits the current Bluetooth permission status to the Dart side.
@@ -96,6 +104,9 @@ class BleCommonUtilities {
   /// * `BluetoothPermissionStatus.DENIED`: Indicates that Bluetooth permission is denied.
   ///
   /// Returns a [Stream] of [BluetoothPermissionStatus] values representing the current Bluetooth permission status on the device.
+  ///
+  /// **Important**: The stream is a broadcast stream, but you should set up your listener immediately after
+  /// calling this method to ensure you receive the initial status emission.
   static Future<Stream<BluetoothPermissionStatus>> emitCurrentPermissionStatus(
     MethodChannel channel,
   ) async {
@@ -107,7 +118,8 @@ class BleCommonUtilities {
         final String permissionStatusString = call.arguments as String;
 
         // Convert the string status to its corresponding enum value
-        final BluetoothPermissionStatus status = BluetoothPermissionStatus.values.firstWhere(
+        final BluetoothPermissionStatus status =
+            BluetoothPermissionStatus.values.firstWhere(
           (status) => status.identifier == permissionStatusString,
         );
 
@@ -115,8 +127,11 @@ class BleCommonUtilities {
       }
     });
 
-    // Begin emitting Bluetooth permission status updates from the platform side.
-    await channel.invokeMethod('emitCurrentPermissionStatus');
+    // Use a microtask to ensure the stream is returned before the native method is invoked
+    // This gives the caller a chance to set up their listener before the first value is emitted
+    unawaited(Future.microtask(() async {
+      await channel.invokeMethod('emitCurrentPermissionStatus');
+    }));
 
     return streamController.stream;
   }

--- a/test/emit_current_permission_status_test.dart
+++ b/test/emit_current_permission_status_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_splendid_ble/central/central_method_channel.dart';
+import 'package:flutter_splendid_ble/shared/models/bluetooth_permission_status.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('flutter_splendid_ble_central');
+
+  _testEmitCurrentPermissionStatus(channel);
+}
+
+/// Tests that the `emitCurrentPermissionStatus` method correctly emits permission status updates
+/// from the platform side to the Dart side.
+void _testEmitCurrentPermissionStatus(MethodChannel channel) {
+  for (final BluetoothPermissionStatus status
+      in BluetoothPermissionStatus.values) {
+    test('emitCurrentPermissionStatus emits $status', () async {
+      final CentralMethodChannel methodChannelFlutterBle =
+          CentralMethodChannel();
+      final Completer<BluetoothPermissionStatus> completer =
+          Completer<BluetoothPermissionStatus>();
+
+      // Set up the mock handler
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        channel,
+        (MethodCall methodCall) async {
+          if (methodCall.method == 'emitCurrentPermissionStatus') {
+            // Simulate the platform side emitting a permission status update
+            Future.delayed(const Duration(milliseconds: 100), () {
+              TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+                  .handlePlatformMessage(
+                channel.name,
+                channel.codec.encodeMethodCall(
+                  MethodCall('permissionStatusUpdated', status.identifier),
+                ),
+                (ByteData? data) {},
+              );
+            });
+            return null;
+          }
+          return null;
+        },
+      );
+
+      // Get the stream and listen for the first emission
+      final Stream<BluetoothPermissionStatus> permissionStream =
+          await methodChannelFlutterBle.emitCurrentPermissionStatus();
+
+      permissionStream.listen((BluetoothPermissionStatus emittedStatus) {
+        if (!completer.isCompleted) {
+          completer.complete(emittedStatus);
+        }
+      });
+
+      // Wait for the emission with a timeout
+      final BluetoothPermissionStatus result =
+          await completer.future.timeout(const Duration(seconds: 2));
+
+      // Verify the emitted status matches the expected status
+      expect(result, status);
+
+      // Clean up
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, null);
+    });
+  }
+}

--- a/test/request_bluetooth_permissions_test.dart
+++ b/test/request_bluetooth_permissions_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_splendid_ble/central/central_method_channel.dart';
+import 'package:flutter_splendid_ble/shared/models/bluetooth_permission_status.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const MethodChannel channel = MethodChannel('flutter_splendid_ble_central');
+
+  group('requestBluetoothPermissions', () {
+    for (final BluetoothPermissionStatus status
+        in BluetoothPermissionStatus.values) {
+      test('returns $status', () async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          channel,
+          (MethodCall methodCall) async {
+            if (methodCall.method == 'requestBluetoothPermissions') {
+              return status.identifier; // Mock the behavior of the native code
+            }
+            return null;
+          },
+        );
+
+        final CentralMethodChannel methodChannelFlutterBle =
+            CentralMethodChannel();
+        final BluetoothPermissionStatus result =
+            await methodChannelFlutterBle.requestBluetoothPermissions();
+
+        // Check if the function returns the expected value
+        expect(result, status);
+
+        // Clean up
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(
+          channel,
+          null,
+        );
+      });
+    }
+  });
+}


### PR DESCRIPTION
Fixes #7 - MissingPluginException for requestBluetoothPermissions and emitCurrentPermissionStatus

[issues/7](https://github.com/Toglefritz/flutter_splendid_ble/issues/7)

Changes
Android Implementation:

Added BluetoothPermissionsHandler class to manage Bluetooth permissions across Android versions
Automatically requests appropriate permissions based on API level:
Android 12+ (API 31+): BLUETOOTH_SCAN and BLUETOOTH_CONNECT
Android 10-11 (API 29-30): ACCESS_FINE_LOCATION
Android 6-9 (API 23-28): ACCESS_FINE_LOCATION
Updated FlutterSplendidBlePlugin to implement ActivityAware for proper permission request handling
Updated AndroidManifest.xml with version-specific permission declarations