### PR TITLE
Updated filtering by UUID on Android

### DIFF
--- a/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/scanner/BleScannerHandler.kt
+++ b/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/scanner/BleScannerHandler.kt
@@ -115,7 +115,8 @@ class BleScannerHandler(private val channel: MethodChannel, activity: Context) {
                             "name" to it.device.name,
                             "address" to it.device.address,
                             "rssi" to it.rssi,
-                            "manufacturerData" to manufacturerData
+                            "manufacturerData" to manufacturerData,
+                            "advertisedServiceUuids" to (it.scanRecord?.serviceUuids?.map { parcelUuid -> parcelUuid.toString() } ?: emptyList()),
                             // ... add other details as needed
                         )
 


### PR DESCRIPTION
Previously, the primary service UUID for detected BLE devices was not passed back to the Dart/Flutter side. This prevented the Dart side from applying the scan filters.