### PR TITLE
Feature/update scan response handling

### DIFF
--- a/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/FlutterSplendidBlePlugin.kt
+++ b/android/src/main/kotlin/com/splendidendeavors/flutter_splendid_ble/FlutterSplendidBlePlugin.kt
@@ -400,13 +400,14 @@ class FlutterSplendidBlePlugin : FlutterPlugin, MethodCallHandler, ActivityAware
                 if (deviceAddress != null && characteristicUuidStr != null) {
                     val characteristicUuid = UUID.fromString(characteristicUuidStr)
                     try {
-                        // The actual implementation logic for subscribing to the characteristic
+                        // Pass result to complete later when descriptor write finishes
                         bleDeviceInterface.subscribeToCharacteristic(
                             deviceAddress,
                             characteristicUuid,
-                            true
+                            true,
+                            result // Result will be completed in onDescriptorWrite callback
                         )
-                        result.success(null)
+                        // Don't call result.success here - it will be called in onDescriptorWrite callback
                     } catch (e: Exception) {
                         result.error(
                             "SUBSCRIBE_ERROR",
@@ -430,16 +431,17 @@ class FlutterSplendidBlePlugin : FlutterPlugin, MethodCallHandler, ActivityAware
                 if (deviceAddress != null && characteristicUuidStr != null) {
                     val characteristicUuid = UUID.fromString(characteristicUuidStr)
                     try {
-                        // The actual implementation logic for subscribing to the characteristic
+                        // Pass result to complete later when descriptor write finishes
                         bleDeviceInterface.subscribeToCharacteristic(
                             deviceAddress,
                             characteristicUuid,
-                            false
+                            false,
+                            result // Result will be completed in onDescriptorWrite callback
                         )
-                        result.success(null)
+                        // Don't call result.success here - it will be called in onDescriptorWrite callback
                     } catch (e: Exception) {
                         result.error(
-                            "SUBSCRIBE_ERROR",
+                            "UNSUBSCRIBE_ERROR",
                             "Failed to unsubscribe from characteristic: ${e.message}",
                             null
                         )

--- a/ios/Classes/FlutterSplendidBlePlugin.swift
+++ b/ios/Classes/FlutterSplendidBlePlugin.swift
@@ -148,6 +148,10 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
                 }
             }
             
+            // Clear previous scan session data
+            discoveredDevices.removeAll()
+            partialAdvertisementData.removeAll()
+
             // Start scanning with optional service UUIDs and options.
             centralManager.scanForPeripherals(withServices: serviceUUIDs, options: options)
             result(nil)
@@ -155,6 +159,9 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
         case CentralMethod.stopScan.rawValue:
             // Stop scanning for BLE devices
             centralManager.stopScan()
+            // Clear scan session data
+            discoveredDevices.removeAll()
+            partialAdvertisementData.removeAll()
             result(nil)
             
         case CentralMethod.connect.rawValue:
@@ -322,56 +329,97 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
         // Add the peripheral to the map
         peripheralsMap[peripheral.identifier.uuidString] = peripheral
         
-        // Check if the BLE device has indicated it supports scannable advertisement packets. If this is the case, the OS will automatically send a
-        // scan request and this function should receive another call when the scan response is received. This function will wait until all
-        // advertisement data is collected before returning it to the Dart side.
-        let isScannable = (advertisementData[CBAdvertisementDataIsConnectable] as? Bool ?? false) && discoveredDevices.contains(peripheral.identifier) == false
-        
-        // Add the device to the list of discovered devices if it has not already been added
-        if discoveredDevices.contains(peripheral.identifier) == false {
-            discoveredDevices.append(peripheral.identifier)
-        }
-        
-        // If the device does not indicate that more advertisement data is forthcoming, return the scan discovery information to the Dart side
-        if(!isScannable) {
-            // Get a list of service UUIDs as strings, to be sent to the Dart side.
-            let advertisedServiceUuids = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.map { $0.uuidString }
+        // Determine if this is the first time we're seeing this device
+        let isFirstDiscovery: Bool = !discoveredDevices.contains(peripheral.identifier)
 
-            // Create a dictionary with device details
-            var deviceMap: [String: Any?] = [
-                "name": peripheral.name,
-                "address": peripheral.identifier.uuidString,
-                "advertisedServiceUuids": advertisedServiceUuids,
-                "rssi": RSSI.intValue,
-            ]
-            
-            // Extract the manufacturer data
-            let manufacturerData = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
-            
-            // Process the manufacturer data if it exists
-            if let manufacturerData = manufacturerData {
-                // Check that the data is at least 2 bytes long (to extract the manufacturer identifier)
-                if manufacturerData.count >= 2 {
-                    // Extract the manufacturer identifier (first two bytes)
-                    let manufacturerIdData = manufacturerData.subdata(in: 0..<2)
-                    // Extract the manufacturer-specific payload (the remaining bytes)
-                    let manufacturerPayloadData = manufacturerData.subdata(in: 2..<manufacturerData.count)
-                    
-                    // Convert both the data parts into uppercase hexadecimal strings
-                    let manufacturerIdHex = manufacturerIdData.map { String(format: "%02X", $0) }.joined()
-                    let manufacturerPayloadHex = manufacturerPayloadData.map { String(format: "%02X", $0) }.joined()
-                    
-                    let formattedManufacturerData = "\(manufacturerIdHex)\(manufacturerPayloadHex)"
-                    
-                    deviceMap["manufacturerData"] = formattedManufacturerData
+        // Check if the device is connectable, which may indicate it supports scan responses
+        let isConnectable: Bool = advertisementData[CBAdvertisementDataIsConnectable] as? Bool ?? false
+
+        if isFirstDiscovery {
+            // Mark this device as discovered
+            discoveredDevices.insert(peripheral.identifier)
+
+            // If the device is connectable, it might send a scan response. Store the initial data and wait.
+            if isConnectable {
+                partialAdvertisementData[peripheral.identifier] = (data: advertisementData, rssi: RSSI)
+                return // Don't emit yet - wait for potential scan response
+            }
+
+            // Device is not connectable, so no scan response is expected. Emit immediately.
+            emitDeviceDiscovery(peripheral: peripheral, advertisementData: advertisementData, rssi: RSSI)
+        } else {
+            // This is a subsequent discovery - likely a scan response or duplicate advertisement
+
+            // Check if we have stored partial data (meaning we're waiting for scan response)
+            if let partialData = partialAdvertisementData[peripheral.identifier] {
+                // This is the scan response. Merge the data and emit.
+                var mergedAdvertisementData: [String: Any] = partialData.data
+
+                // Merge the scan response data into the initial advertisement data
+                for (key, value) in advertisementData {
+                    mergedAdvertisementData[key] = value
                 }
+
+                // Clean up the partial data storage
+                partialAdvertisementData.removeValue(forKey: peripheral.identifier)
+
+                // Emit the complete device information with merged data
+                emitDeviceDiscovery(peripheral: peripheral, advertisementData: mergedAdvertisementData, rssi: RSSI)
+            } else {
+                // We've seen this device before but aren't waiting for scan response
+                // This is a duplicate advertisement - emit it
+                emitDeviceDiscovery(peripheral: peripheral, advertisementData: advertisementData, rssi: RSSI)
             }
-            
-            // Send device information to Flutter side
-            let jsonData = try? JSONSerialization.data(withJSONObject: deviceMap, options: [])
-            if let jsonData = jsonData, let jsonString = String(data: jsonData, encoding: .utf8) {
-                channel.invokeMethod("bleDeviceScanned", arguments: jsonString)
+        }
+    }
+
+    /// Emits device discovery information to the Flutter/Dart side.
+    ///
+    /// This method formats the peripheral's advertisement data and sends it through the method channel
+    /// to notify the Flutter side that a BLE device has been discovered.
+    ///
+    /// - Parameters:
+    ///   - peripheral: The discovered `CBPeripheral` device.
+    ///   - advertisementData: The complete advertisement data for the device.
+    ///   - rssi: The received signal strength indicator (RSSI) value.
+    private func emitDeviceDiscovery(peripheral: CBPeripheral, advertisementData: [String: Any], rssi: NSNumber) {
+        // Get a list of service UUIDs as strings, to be sent to the Dart side.
+        let advertisedServiceUuids: [String]? = (advertisementData[CBAdvertisementDataServiceUUIDsKey] as? [CBUUID])?.map { $0.uuidString }
+
+        // Create a dictionary with device details
+        var deviceMap: [String: Any?] = [
+            "name": peripheral.name,
+            "address": peripheral.identifier.uuidString,
+            "advertisedServiceUuids": advertisedServiceUuids,
+            "rssi": rssi.intValue,
+        ]
+
+        // Extract the manufacturer data
+        let manufacturerData: Data? = advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data
+
+        // Process the manufacturer data if it exists
+        if let manufacturerData = manufacturerData {
+            // Check that the data is at least 2 bytes long (to extract the manufacturer identifier)
+            if manufacturerData.count >= 2 {
+                // Extract the manufacturer identifier (first two bytes)
+                let manufacturerIdData: Data = manufacturerData.subdata(in: 0..<2)
+                // Extract the manufacturer-specific payload (the remaining bytes)
+                let manufacturerPayloadData: Data = manufacturerData.subdata(in: 2..<manufacturerData.count)
+
+                // Convert both the data parts into uppercase hexadecimal strings
+                let manufacturerIdHex: String = manufacturerIdData.map { String(format: "%02X", $0) }.joined()
+                let manufacturerPayloadHex: String = manufacturerPayloadData.map { String(format: "%02X", $0) }.joined()
+
+                let formattedManufacturerData: String = "\(manufacturerIdHex)\(manufacturerPayloadHex)"
+
+                deviceMap["manufacturerData"] = formattedManufacturerData
             }
+        }
+
+        // Send device information to Flutter side
+        let jsonData: Data? = try? JSONSerialization.data(withJSONObject: deviceMap, options: [])
+        if let jsonData = jsonData, let jsonString = String(data: jsonData, encoding: .utf8) {
+            channel.invokeMethod("bleDeviceScanned", arguments: jsonString)
         }
     }
     

--- a/lib/shared/models/manufacturer_data.dart
+++ b/lib/shared/models/manufacturer_data.dart
@@ -70,15 +70,18 @@ class ManufacturerData {
     return String.fromCharCodes(manufacturerDataInts);
   }
 
-  /// Converts the manufacturer data to a string that is formatted for easy reading. The manufacturer identifier is
-  /// surrounded by angle brackets to make its separation from the rest of the data more clear. A space is included
-  /// after every fourth character to separate the manufacturer data into chunks of four characters.
+  /// Converts the manufacturer data to a hexadecimal string format for easy reading.
   ///
-  /// The end result of this formatting is a value that looks similar to the format used by the nRF Connect for Mobile
-  /// app.
+  /// The manufacturer identifier is surrounded by angle brackets to make its separation
+  /// from the rest of the data more clear. Each byte is represented as a two-digit
+  /// hexadecimal value with spaces between bytes for readability.
+  ///
+  /// Example output: `<4C00> 02 15 A1 B2 C3 D4 ...`
+  ///
+  /// The format is similar to that used by the nRF Connect for Mobile app.
   String toFormattedString() {
     // Create a string representing the manufacturer identifier, surrounded by
-    //angle brackets.
+    // angle brackets.
     final StringBuffer formattedString = StringBuffer('<');
     for (int i = 0; i < manufacturerId.length; i++) {
       formattedString
@@ -86,13 +89,13 @@ class ManufacturerData {
     }
     formattedString.write('> ');
 
-    // Create a string representing the payload, with spaces after every fourth
-    // character.
+    // Create a string representing the payload, with spaces between each byte
+    // (two hex characters).
     for (int i = 0; i < payload.length; i++) {
-      formattedString.write(payload[i].toRadixString(16).padLeft(2, '0'));
-      if ((i + 1).isEven) {
+      if (i > 0) {
         formattedString.write(' ');
       }
+      formattedString.write(payload[i].toRadixString(16).padLeft(2, '0'));
     }
 
     return formattedString.toString().toUpperCase();

--- a/macos/Classes/FlutterSplendidBlePlugin.swift
+++ b/macos/Classes/FlutterSplendidBlePlugin.swift
@@ -422,13 +422,18 @@ public class FlutterSplendidBlePlugin: NSObject, FlutterPlugin, CBCentralManager
     }
     
     /// Called by the system when a connection to the peripheral is successfully established.
+    ///
     /// This method triggers a callback to the Flutter side to inform it of the connection status.
     /// It is important for managing state on the Flutter side, such as updating UI elements or handling connected devices.
     /// - Parameters:
     ///   - central: The `CBCentralManager` that has initiated the connection.
     ///   - peripheral: The `CBPeripheral` to which the app has just successfully connected.
     public func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
-        centralChannel.invokeMethod("bleConnectionState_\(peripheral.identifier.uuidString)", arguments: "CONNECTED")
+        // Wait 100ms for macOS BLE stack to complete connection initialization
+        // before reporting CONNECTED to Flutter
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            self?.centralChannel.invokeMethod("bleConnectionState_\(peripheral.identifier.uuidString)", arguments: "CONNECTED")
+        }
     }
     
     /// Called by the system when the central manager fails to create a connection with the peripheral.


### PR DESCRIPTION
This PR updates the way the plugin handles devices that offer scan responses. The plugin will provide all scan response data to the Flutter side at once. So, if a BLE device offers scan response data, scan information will only be sent to the Flutter side after the scan response is received. This prevents the Flutter app from receiving partial discovery data.